### PR TITLE
[Extra] Add GitHub repo link in footer.

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -121,6 +121,7 @@
     <% end %>
     <%= link_to 'Filter', filters_path %>
     <%= link_to 'Moderation Log', moderations_path %>
+    <%= link_to 'GitHub', "https://github.com/aqora-io/quantumnews" %>
   </footer>
   <span id="iab-pcm-sdk"></span><span id="iab-autofill-sdk"></span>
 </body>


### PR DESCRIPTION
## Objective
- This PR adds a direct link between the website and the repository, enhancing visibility and community engagement for the repository!

## Demo 
![image](https://github.com/aqora-io/quantumnews/assets/77701490/5c1e040a-d269-4d41-85da-aa8f5164cdc3)

I put a direct link to the repository, but we can put a link to the GitHub organization, what do you think?