### PR TITLE
allow for local development with app.aqora.io oauth

### DIFF
--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -32,7 +32,16 @@ class LoginController < ApplicationController
 
   def aqora_auth
     session[:aqora_state] = SecureRandom.hex
-    redirect_to Aqora.oauth_auth_url(session[:aqora_state]), allow_other_host: true
+    redirect_uri = url_for(
+      controller: 'login',
+      action: 'aqora_callback',
+      host: request.host,
+      protocol: request.protocol
+    )
+    redirect_to(
+      Aqora.oauth_auth_url(session[:aqora_state], redirect_uri),
+      allow_other_host: true
+    )
   end
 
   def aqora_callback

--- a/config/application.rb
+++ b/config/application.rb
@@ -70,6 +70,9 @@ module Lobsters
 
     # rails stop putting js on everything
     config.action_view.form_with_generates_remote_forms = false
+
+    # default to no cookie consent config
+    config.cookie_consent_config_js = nil
   end
 end
 


### PR DESCRIPTION
This PR should allow for local development with app.aqora.io as the OAuth
provider (as requested by #32). To setup local development:

```bash
# clone repo
git clone https://github.com/aqora-io/quantumnews
cd quantumnews

# install dependencies
bundle install

# configure a database
export DATABASE_URL="mysql2://user:password@localhost:3306/db?encoding=utf8mb4"

# create the database if it does not exist
bin/rails db:create

# setup the database
bin/setup

# configure the OAuth client
echo "Aqora.client_id = 'localhost-news'" > config/initializers/development.rb

# run the server
bin/rails server
```
