### PR TITLE
[Markdowner] Add math engine + syntax highlighter.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,8 @@ gem "parslet"
 gem "kramdown"
 gem "kramdown-parser-gfm"
 gem "kramdown-math-katex"
+gem "kramdown-math-itex2mml"
+gem "kramdown-math-sskatex"
 
 # perf
 gem "flamegraph"

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,9 @@ gem "htmlentities"
 gem "pdf-reader"
 gem "nokogiri"
 gem "parslet"
+gem "kramdown"
+gem "kramdown-parser-gfm"
+gem "kramdown-math-katex"
 
 # perf
 gem "flamegraph"

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,6 @@ gem "rotp"
 gem "rqrcode"
 
 # parsing
-gem "commonmarker", "<1"
 gem "htmlentities"
 gem "pdf-reader"
 gem "nokogiri"
@@ -34,8 +33,7 @@ gem "parslet"
 gem "kramdown"
 gem "kramdown-parser-gfm"
 gem "kramdown-math-katex"
-gem "kramdown-math-itex2mml"
-gem "kramdown-math-sskatex"
+gem "kramdown-syntax-coderay", "~> 1.0"
 
 # perf
 gem "flamegraph"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,14 +150,21 @@ GEM
     irb (1.11.1)
       rdoc
       reline (>= 0.4.2)
+    itextomml (1.6.1)
     json (2.7.1)
     katex (0.10.0)
       execjs (~> 2.8)
     kramdown (2.4.0)
       rexml
+    kramdown-math-itex2mml (1.0.0)
+      itextomml (~> 1.5)
+      kramdown (~> 2.0)
     kramdown-math-katex (1.0.1)
       katex (~> 0.4)
       kramdown (~> 2.0)
+    kramdown-math-sskatex (1.0.0)
+      kramdown (~> 2.0)
+      sskatex (>= 0.9.37)
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     language_server-protocol (3.17.0.3)
@@ -355,6 +362,8 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    sskatex (0.9.39)
+      execjs (~> 2.7)
     stackprof (0.2.25)
     standard (1.33.0)
       language_server-protocol (~> 3.17.0.2)
@@ -425,7 +434,9 @@ DEPENDENCIES
   htmlentities
   json
   kramdown
+  kramdown-math-itex2mml
   kramdown-math-katex
+  kramdown-math-sskatex
   kramdown-parser-gfm
   listen
   mail

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,6 +151,15 @@ GEM
       rdoc
       reline (>= 0.4.2)
     json (2.7.1)
+    katex (0.10.0)
+      execjs (~> 2.8)
+    kramdown (2.4.0)
+      rexml
+    kramdown-math-katex (1.0.1)
+      katex (~> 0.4)
+      kramdown (~> 2.0)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
     language_server-protocol (3.17.0.3)
     lint_roller (1.1.0)
     listen (3.8.0)
@@ -415,6 +424,9 @@ DEPENDENCIES
   graphql-client
   htmlentities
   json
+  kramdown
+  kramdown-math-katex
+  kramdown-parser-gfm
   listen
   mail
   memory_profiler

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     chunky_png (1.4.0)
-    commonmarker (0.23.10)
+    coderay (1.1.3)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
     crack (0.4.5)
@@ -150,22 +150,18 @@ GEM
     irb (1.11.1)
       rdoc
       reline (>= 0.4.2)
-    itextomml (1.6.1)
     json (2.7.1)
     katex (0.10.0)
       execjs (~> 2.8)
     kramdown (2.4.0)
       rexml
-    kramdown-math-itex2mml (1.0.0)
-      itextomml (~> 1.5)
-      kramdown (~> 2.0)
     kramdown-math-katex (1.0.1)
       katex (~> 0.4)
       kramdown (~> 2.0)
-    kramdown-math-sskatex (1.0.0)
-      kramdown (~> 2.0)
-      sskatex (>= 0.9.37)
     kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    kramdown-syntax-coderay (1.0.1)
+      coderay (~> 1.1)
       kramdown (~> 2.0)
     language_server-protocol (3.17.0.3)
     lint_roller (1.1.0)
@@ -362,8 +358,6 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sskatex (0.9.39)
-      execjs (~> 2.7)
     stackprof (0.2.25)
     standard (1.33.0)
       language_server-protocol (~> 3.17.0.2)
@@ -423,7 +417,6 @@ DEPENDENCIES
   brakeman
   byebug
   capybara
-  commonmarker (< 1)
   database_cleaner
   exception_notification
   factory_bot_rails
@@ -434,10 +427,9 @@ DEPENDENCIES
   htmlentities
   json
   kramdown
-  kramdown-math-itex2mml
   kramdown-math-katex
-  kramdown-math-sskatex
   kramdown-parser-gfm
+  kramdown-syntax-coderay (~> 1.0)
   listen
   mail
   memory_profiler

--- a/app/views/global/_markdownhelp.html.erb
+++ b/app/views/global/_markdownhelp.html.erb
@@ -37,5 +37,17 @@
       <td><tt>![alt text](http://example.com/image.jpg)</tt></td>
     </tr>
   <% end %>
+    <tr>
+    <td width="125"><code>code block</code></td>
+    <td>surround text with <tt>```</tt> for multiple lines</td>
+  </tr>
+  <tr>
+    <td><code>one line code</code></td>
+    <td>surround text with <tt>`backticks`</tt></td>
+  </tr>
+  <tr>
+    <td><code>LaTeX input</code></td>
+    <td>use <tt>$$ ... $$</tt> for display math</td>
+  </tr>
   </table>
 </div>

--- a/extras/markdowner.rb
+++ b/extras/markdowner.rb
@@ -77,9 +77,7 @@ class Markdowner
   def self.convert_images_to_links(node)
     node.css('img').each do |img|
       link = Nokogiri::XML::Node.new('a', node)
-      link['href'] = img['src']
-      title = img['title']
-      alt = img['alt']
+      link['href'], title, alt = img.attributes.values_at('src', 'title', 'alt').map(&:to_s)
       link.content = [title, alt, link['href']].find(&:present?)
       img.replace(link)
     end

--- a/extras/markdowner.rb
+++ b/extras/markdowner.rb
@@ -7,8 +7,9 @@ require 'nokogiri'
 
 # Class responsible for converting Markdown to HTML.
 class Markdowner
+  # opts[:allow_images] allows <img> tags
+
   DEFAULT_MATHS_OPTIONS = {
-    katex_js_path: 'extras/katex/katex.min.js',
     output: 'mathml',
     display_mode: true,
     fleqn: true,
@@ -23,12 +24,12 @@ class Markdowner
     ]
   }
 
-  def self.to_html(text, options = {})
+  def self.to_html(text, opts = {})
     return '' if text.blank?
 
-    # Convert Markdown to HTML using Kramdown
+
     html = Kramdown::Document.new(
-      text, math_engine: :katex,
+      text.to_s, math_engine: :katex,
       math_engine_opts: DEFAULT_MATHS_OPTIONS,
       input: 'GFM',
       syntax_highlighter: :coderay,
@@ -38,22 +39,20 @@ class Markdowner
       },
     ).to_html
 
-    # Example: Replace @username with a link to the user's profile
     html = replace_user_mentions(html)
 
     # Parse HTML using Nokogiri
-    ng = Nokogiri::HTML.fragment(html)
+    ng = Nokogiri::HTML5.fragment(html)
 
     # Change <h1>, <h2>, etc. headings to just bold tags
     change_headings_to_bold(ng)
 
     # This should happen before adding rel=ugc to all links
-    convert_images_to_links(ng) unless options[:allow_images]
+    convert_images_to_links(ng) unless opts[:allow_images]
 
     # Make links have rel=ugc
     make_links_ugc(ng)
 
-    # Return the HTML content
     ng.to_html
   end
 

--- a/extras/markdowner.rb
+++ b/extras/markdowner.rb
@@ -1,104 +1,57 @@
 # typed: false
-
-require "commonmarker"
-require 'kramdown'
-require 'kramdown-math-katex'
-require "kramdown-parser-gfm"
+require "kramdown"
+require "kramdown-math-itex2mml"
 
 class Markdowner
-  # opts[:allow_images] allows <img> tags
-
   def self.to_html(text, opts = {})
     if text.blank?
       return ""
     end
 
-    text = Kramdown::Document.new(text, math_engine: :katex, input: 'GFM').to_html
+    # Convert Markdown to HTML using Krakdown
+    html = Kramdown::Document.new(text, math_engine: :itex2mml, input: 'GFM').to_html
 
-    # exts = [:tagfilter, :autolink, :strikethrough]
-    # root = CommonMarker.render_doc(text.to_s, [:SMART], exts)
-
-    # walk_text_nodes(root) { |n| postprocess_text_node(n) }
-
-    # ng = Nokogiri::HTML(root.to_html([:DEFAULT], exts))
-
-    # # change <h1>, <h2>, etc. headings to just bold tags
-    # ng.css("h1, h2, h3, h4, h5, h6").each do |h|
-    #   h.name = "strong"
-    # end
-
-    # # This should happen before adding rel=ugc to all links
-    # convert_images_to_links(ng) unless opts[:allow_images]
-
-    # # make links have rel=ugc
-    # ng.css("a").each do |h|
-    #   h[:rel] = "ugc" unless begin
-    #     URI.parse(h[:href]).host.nil?
-    #   rescue
-    #     false
-    #   end
-    # end
-
-    # if ng.at_css("body")
-    #   ng.at_css("body").inner_html
-    # else
-    #   ""
-    # end
-  end
-
-  def self.walk_text_nodes(node, &block)
-    return if node.type == :link
-    return block.call(node) if node.type == :text
-
-    node.each do |child|
-      walk_text_nodes(child, &block)
-    end
-  end
-
-  def self.postprocess_text_node(node)
-    while node
-      return unless node.string_content =~ /\B(@#{User::VALID_USERNAME})/o
-      before, user, after = $`, $1, $'
-
-      node.string_content = before
-
-      if User.exists?(username: user[1..])
-        link = CommonMarker::Node.new(:link)
-        link.url = Rails.application.root_url + "~#{user[1..]}"
-        node.insert_after(link)
-
-        link_text = CommonMarker::Node.new(:text)
-        link_text.string_content = user
-        link.append_child(link_text)
-
-        node = link
+    html.gsub!(/@(\\w+)/) do |match|
+      username = $1
+      if User.exists?(username: username)
+        "<a href='#{Rails.application.root_url}~#{username}'>#{match}</a>"
       else
-        node.string_content += user
-      end
-
-      if after.length > 0
-        remainder = CommonMarker::Node.new(:text)
-        remainder.string_content = after
-        node.insert_after(remainder)
-
-        node = remainder
-      else
-        node = nil
+        match
       end
     end
+
+    # Parse HTML using Nokogiri
+    ng = Nokogiri::HTML5(html)
+
+    # change <h1>, <h2>, etc. headings to just bold tags
+    ng.css("h1, h2, h3, h4, h5, h6").each do |h|
+      h.name = "strong"
+    end
+
+    # This should happen before adding rel=ugc to all links
+    convert_images_to_links(ng) unless opts[:allow_images]
+
+    # make links have rel=ugc
+    ng.css("a").each do |h|
+      h[:rel] = "ugc" unless begin
+        URI.parse(h[:href]).host.nil?
+      rescue
+        false
+      end
+    end
+
+    ng.to_html
   end
 
   def self.convert_images_to_links(node)
     node.css("img").each do |img|
-      link = node.create_element("a")
-
-      link["href"], title, alt = img.attributes
-        .values_at("src", "title", "alt")
-        .map(&:to_s)
-
+      link = Nokogiri::XML::Node.new("a", node)
+      link["href"] = img["src"]
+      title = img["title"]
+      alt = img["alt"]
       link.content = [title, alt, link["href"]].find(&:present?)
-
-      img.replace link
+      img.replace(link)
     end
   end
 end
+

--- a/extras/markdowner.rb
+++ b/extras/markdowner.rb
@@ -1,6 +1,9 @@
 # typed: false
 
 require "commonmarker"
+require 'kramdown'
+require 'kramdown-math-katex'
+require "kramdown-parser-gfm"
 
 class Markdowner
   # opts[:allow_images] allows <img> tags
@@ -10,35 +13,37 @@ class Markdowner
       return ""
     end
 
-    exts = [:tagfilter, :autolink, :strikethrough]
-    root = CommonMarker.render_doc(text.to_s, [:SMART], exts)
+    text = Kramdown::Document.new(text, math_engine: :katex, input: 'GFM').to_html
 
-    walk_text_nodes(root) { |n| postprocess_text_node(n) }
+    # exts = [:tagfilter, :autolink, :strikethrough]
+    # root = CommonMarker.render_doc(text.to_s, [:SMART], exts)
 
-    ng = Nokogiri::HTML(root.to_html([:DEFAULT], exts))
+    # walk_text_nodes(root) { |n| postprocess_text_node(n) }
 
-    # change <h1>, <h2>, etc. headings to just bold tags
-    ng.css("h1, h2, h3, h4, h5, h6").each do |h|
-      h.name = "strong"
-    end
+    # ng = Nokogiri::HTML(root.to_html([:DEFAULT], exts))
 
-    # This should happen before adding rel=ugc to all links
-    convert_images_to_links(ng) unless opts[:allow_images]
+    # # change <h1>, <h2>, etc. headings to just bold tags
+    # ng.css("h1, h2, h3, h4, h5, h6").each do |h|
+    #   h.name = "strong"
+    # end
 
-    # make links have rel=ugc
-    ng.css("a").each do |h|
-      h[:rel] = "ugc" unless begin
-        URI.parse(h[:href]).host.nil?
-      rescue
-        false
-      end
-    end
+    # # This should happen before adding rel=ugc to all links
+    # convert_images_to_links(ng) unless opts[:allow_images]
 
-    if ng.at_css("body")
-      ng.at_css("body").inner_html
-    else
-      ""
-    end
+    # # make links have rel=ugc
+    # ng.css("a").each do |h|
+    #   h[:rel] = "ugc" unless begin
+    #     URI.parse(h[:href]).host.nil?
+    #   rescue
+    #     false
+    #   end
+    # end
+
+    # if ng.at_css("body")
+    #   ng.at_css("body").inner_html
+    # else
+    #   ""
+    # end
   end
 
   def self.walk_text_nodes(node, &block)

--- a/extras/markdowner.rb
+++ b/extras/markdowner.rb
@@ -1,57 +1,99 @@
-# typed: false
-require "kramdown"
-require "kramdown-math-itex2mml"
+# typed : false
 
+require 'kramdown'
+require 'kramdown-math-katex'
+require 'kramdown-syntax-coderay'
+require 'nokogiri'
+
+# Class responsible for converting Markdown to HTML.
 class Markdowner
-  def self.to_html(text, opts = {})
-    if text.blank?
-      return ""
+  DEFAULT_MATHS_OPTIONS = {
+    katex_js_path: 'extras/katex/katex.min.js',
+    output: 'mathml',
+    display_mode: true,
+    fleqn: true,
+    leqno: true,
+    delimiters: [
+      { left: '$$', right: '$$', display: true },
+      { left: '$', right: '$', display: false },
+      { left: '\(', right: '\)', display: false },
+      { left: '\[', right: '\]', display: true },
+      { left: '\\begin{equation}', right: '\\end{equation}', display: true },
+      { left: '\\begin{align}', right: '\\end{align}', display: true }
+    ]
+  }
+
+  def self.to_html(text, options = {})
+    return '' if text.blank?
+
+    # Convert Markdown to HTML using Kramdown
+    html = Kramdown::Document.new(
+      text, math_engine: :katex,
+      math_engine_opts: DEFAULT_MATHS_OPTIONS,
+      input: 'GFM',
+      syntax_highlighter: :coderay,
+      syntax_highlighter_opts: {
+        line_numbers: 'table',
+        bold_every: 5
+      },
+    ).to_html
+
+    # Example: Replace @username with a link to the user's profile
+    html = replace_user_mentions(html)
+
+    # Parse HTML using Nokogiri
+    ng = Nokogiri::HTML.fragment(html)
+
+    # Change <h1>, <h2>, etc. headings to just bold tags
+    change_headings_to_bold(ng)
+
+    # This should happen before adding rel=ugc to all links
+    convert_images_to_links(ng) unless options[:allow_images]
+
+    # Make links have rel=ugc
+    make_links_ugc(ng)
+
+    # Return the HTML content
+    ng.to_html
+  end
+
+  def self.change_headings_to_bold(fragment)
+    fragment.css('h1, h2, h3, h4, h5, h6').each do |h|
+      h.name = 'strong'
     end
+  end
 
-    # Convert Markdown to HTML using Krakdown
-    html = Kramdown::Document.new(text, math_engine: :itex2mml, input: 'GFM').to_html
-
-    html.gsub!(/@(\\w+)/) do |match|
-      username = $1
+  def self.replace_user_mentions(html)
+    html.gsub(%r{(?<!/)@(\w+)}) do |match|
+      username = ::Regexp.last_match(1)
       if User.exists?(username: username)
-        "<a href='#{Rails.application.root_url}~#{username}'>#{match}</a>"
+        "<a href='#{Rails.application.root_url}~#{username}'>@#{username}</a>"
       else
         match
       end
     end
-
-    # Parse HTML using Nokogiri
-    ng = Nokogiri::HTML5(html)
-
-    # change <h1>, <h2>, etc. headings to just bold tags
-    ng.css("h1, h2, h3, h4, h5, h6").each do |h|
-      h.name = "strong"
-    end
-
-    # This should happen before adding rel=ugc to all links
-    convert_images_to_links(ng) unless opts[:allow_images]
-
-    # make links have rel=ugc
-    ng.css("a").each do |h|
-      h[:rel] = "ugc" unless begin
-        URI.parse(h[:href]).host.nil?
-      rescue
-        false
-      end
-    end
-
-    ng.to_html
   end
 
   def self.convert_images_to_links(node)
-    node.css("img").each do |img|
-      link = Nokogiri::XML::Node.new("a", node)
-      link["href"] = img["src"]
-      title = img["title"]
-      alt = img["alt"]
-      link.content = [title, alt, link["href"]].find(&:present?)
+    node.css('img').each do |img|
+      link = Nokogiri::XML::Node.new('a', node)
+      link['href'] = img['src']
+      title = img['title']
+      alt = img['alt']
+      link.content = [title, alt, link['href']].find(&:present?)
       img.replace(link)
     end
   end
-end
 
+  def self.valid_url?(url)
+    URI.parse(url).host.nil?
+  rescue StandardError
+    false
+  end
+
+  def self.make_links_ugc(fragment)
+    fragment.css('a').each do |link|
+      link[:rel] = 'ugc' unless valid_url?(link[:href])
+    end
+  end
+end

--- a/spec/models/markdowner_spec.rb
+++ b/spec/models/markdowner_spec.rb
@@ -127,4 +127,57 @@ describe Markdowner do
       expect(subject).to include "<img"
     end
   end
+
+  context "with LaTeX input" do
+    subject { described_class.to_html("$$ 5 + 5 $$") }
+    let(:expected_html) do
+      '<span class="katex"><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><semantics><mrow><mn>5</mn><mo>+</mo><mn>5</mn></mrow><annotation encoding="application/x-tex">5 + 5</annotation></semantics></math></span>'
+    end
+
+    it "renders LaTeX to HTML" do
+      expect(subject).to include(expected_html)
+    end
+  end
+
+  context "with complex mathematical expressions" do
+    subject { described_class.to_html('$$ \int_{0}^{1} x^2 dx = \frac{1}{3} $$') }
+    let(:expected_html) do
+      '<span class="katex"><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><semantics><mrow><msubsup><mo>∫</mo><mn>0</mn><mn>1</mn></msubsup><msup><mi>x</mi><mn>2</mn></msup><mi>d</mi><mi>x</mi><mo>=</mo><mfrac><mn>1</mn><mn>3</mn></mfrac></mrow><annotation encoding="application/x-tex">\int_{0}^{1} x^2 dx = \frac{1}{3}</annotation></semantics></math></span>'
+    end
+
+    it "renders complex math expressions correctly" do
+      expect(subject).to include(expected_html)
+    end
+  end
+
+  context "with one line code input" do
+    subject {
+      described_class.to_html(
+      '`code`'
+    )}
+    let(:expected_html) do
+      "<p><code>code</code></p>\n"
+    end
+
+    it "renders code input correctly" do
+      expect(subject).to include(expected_html)
+    end
+  end
+  context "with multilines code input" do
+    subject {
+      described_class.to_html(
+      '```rs
+        fn main() {
+            println!("Hello Aquora!");
+        }
+    ```'
+    )}
+    let(:expected_html) do
+      "<p><code>rs\n        fn main() {\n            println!(\"Hello Aquora!\");\n        }\n   </code></p>\n"
+    end
+
+    it "renders code input correctly" do
+      expect(subject).to include(expected_html)
+    end
+  end
 end


### PR DESCRIPTION
## Objective
<!-- This PR fixes/makes X -->
- This PR swaps out `commonmarker` with `kramdown` to integrate a math (LaTeX) parser for Aquora's markdown needs. kramdown offers full SSR support, code syntax highlighting, and emoji support, making it highly functional and easy to use. While I'm hesitant to add dependencies [[`kramdown`](https://github.com/gettalong/kramdown), [`kramdown-math-katex`](https://github.com/kramdown/math-katex)] not actively maintained, my research indicates that this remains the most useful solution.

This marks my first interaction with Ruby/Ruby on Rails, so I may have overlooked something. Feel free to let me know.

## References 
- https://kramdown.gettalong.org/quickref.html
- https://www.ruby-toolbox.com/categories/markup_processors


## Another possible solution : 
- https://github.com/forem/forem/pull/6237/files (Let me know if you have any preferences)


Closes <!-- issue number --> #28 

## Implementation
<!-- Explain how you implemented this -->
- Replace `commonmarker` with `kramdown`  and adapt code to support `kramdown`
- Write unit tests for math and syntax highlighting renders
- Add exemples in 'Markdown formatting available' section. 

## Demo
<!-- Screenshots, screen recordings -->
![image](https://github.com/aqora-io/quantumnews/assets/77701490/89a681eb-81a2-46ba-aab7-a1df5d1942cc)


## Check-list
<!-- How did you test this PR? -->
**Testing** : By testing manually + run unit test with : `bundle exec rspec ./spec/models/markdowner_spec.rb` and write new tests for maths support.

## Tests issues 
My work has led to 2 issues in the test plan. I'm encountering problems with text escaping, as shown below:
```bash
  4) Markdowner when images are not allowed when single inline image in description with alt text turns inline image into links with alt text
     Failure/Error: expect(subject).to eq(target_html(alt_text))

       Expected "<p>![alt text](https://lbst.rs/fake.jpg “”)</p>\n"
          to eq "<p><a href=\"https://lbst.rs/fake.jpg\" rel=\"ugc\">alt text</a></p>\n"

       Diff:

       - <p><a href="https://lbst.rs/fake.jpg" rel="ugc">alt text</a></p>\n
       + <p>![alt text](https://lbst.rs/fake.jpg “”)</p>\n
     # ./spec/models/markdowner_spec.rb:87:in `block (5 levels) in <top (required)>'
``` 
I've tried numerous approaches to address this, but unfortunately, haven't been able to resolve it yet. If you have any suggestions, please let me know.
 
